### PR TITLE
Fixes virtual_path to override menu

### DIFF
--- a/app/assets/stylesheets/spree/frontend/spree_themes.css
+++ b/app/assets/stylesheets/spree/frontend/spree_themes.css
@@ -3,4 +3,4 @@ Placeholder manifest file.
 the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/frontend/all.css'
 */
 
-@import 'theme_preview.css'
+@import 'theme_preview.css';

--- a/app/overrides/spree/admin/add_themes_tab.html.rb
+++ b/app/overrides/spree/admin/add_themes_tab.html.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(
-  virtual_path: 'spree/admin/shared/_main_menu',
+  virtual_path: 'spree/admin/shared/_version',
   name: 'add_themes_tab',
   insert_before: 'div.spree-version',
   partial: 'spree/admin/shared/theme_menu_button'


### PR DESCRIPTION
Fixes this change in spree

https://github.com/spree/spree/commit/7ee0b7d70d99fc040b6986348f1c1b9c1a47e103

Maybe there is a better way to place new menu items?
Like to add to the end of list of menu items, instead of adding before `spree-version`